### PR TITLE
Fix spelling error in README.md, licence/licencing > license/licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ isDuplex(new Stream.PassThrough()) // true
 
 ## License
 
-**isStream** is Copyright (c) 2015 Rod Vagg [@rvagg](https://twitter.com/rvagg) and licenced under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.
+**isStream** is Copyright (c) 2015 Rod Vagg [@rvagg](https://twitter.com/rvagg) and licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.


### PR DESCRIPTION
Minor fix